### PR TITLE
Switch to create-react-class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-meteor-data",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Meteor packages for a great React developer experience",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/jedwards1211/react-meteor-data#readme",
   "dependencies": {},
   "peerDependencies": {
+    "create-react-class": "15.5.1",
     "react": "^0.14.0 || ^15.0.0",
     "react-addons-pure-render-mixin": "^0.14.0 || ^15.0.0"
   },

--- a/src/createContainer.js
+++ b/src/createContainer.js
@@ -2,6 +2,7 @@
  * Container helper using react-meteor-data.
  */
 
+import createClass from 'create-react-class';
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 
@@ -26,7 +27,7 @@ export default function createContainer(options = {}, Component) {
   }
 
   /* eslint-disable react/prefer-es6-class */
-  return React.createClass({
+  return createClass({
     displayName: 'MeteorDataContainer',
     mixins,
     getMeteorData() {


### PR DESCRIPTION
React 15.5 has deprecated React.createClass. This fixes that. Prompted by [this issue](https://github.com/meteor/meteor/issues/8625)